### PR TITLE
🎬 [gha] skip bot PRs in claude-review + rename generic job names

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: Lint GitHub Actions
 
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 jobs:
-  run:
+  run-auto-assign:
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -16,8 +16,7 @@ permissions: {}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "scan"
-  scan:
+  checkov-scan:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,12 @@ permissions: {}
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip review for bot PRs (dependabot, renovate, etc.)
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot-preview[bot]' &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'renovate-preview[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 jobs:
-  lint:
+  markdown-lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes #51 

<!-- PR_BODY_DONE_START -->
## Done

- ci: skip bot PRs in claude-review + rename generic job names
- shorten actionlint outer name

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
